### PR TITLE
Load env file for codegen script

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ O **Codegen** é útil para descobrir seletores automaticamente navegando pela s
 npm run codegen
 ```
 
+- O script usa `dotenv` para carregar automaticamente as variáveis definidas em `env/.env`.
 - Ele abrirá o navegador já apontado para `BASE_URL` configurada no `.env`.
 - Cada clique, digitação ou ação vai gerar código no terminal com os seletores.
 - Exemplo gerado pelo codegen:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "playwright test",
     "test:ui": "playwright test --ui",
-    "codegen": "playwright codegen $BASE_URL"
+    "codegen": "node scripts/codegen.mjs"
   },
   "devDependencies": {
     "@playwright/test": "^1.47.2",

--- a/scripts/codegen.mjs
+++ b/scripts/codegen.mjs
@@ -1,0 +1,53 @@
+import path from 'node:path';
+import process from 'node:process';
+import fs from 'node:fs';
+import { spawn } from 'node:child_process';
+import { config } from 'dotenv';
+
+const cwd = process.cwd();
+const envPath = path.resolve(cwd, 'env/.env');
+
+if (!fs.existsSync(envPath)) {
+  console.error('Arquivo env/.env não foi encontrado.');
+  process.exit(1);
+}
+
+config({ path: envPath });
+
+const baseUrl = process.env.BASE_URL;
+
+if (!baseUrl) {
+  console.error('BASE_URL não está definido em env/.env.');
+  process.exit(1);
+}
+
+const [, , ...extraArgs] = process.argv;
+
+const binDir = path.join(cwd, 'node_modules', '.bin');
+const isWindows = process.platform === 'win32';
+const localPlaywright = path.join(
+  binDir,
+  isWindows ? 'playwright.cmd' : 'playwright',
+);
+const hasLocalPlaywright = fs.existsSync(localPlaywright);
+const command = hasLocalPlaywright
+  ? localPlaywright
+  : isWindows
+    ? 'npx.cmd'
+    : 'npx';
+const args = hasLocalPlaywright
+  ? ['codegen', baseUrl, ...extraArgs]
+  : ['playwright', 'codegen', baseUrl, ...extraArgs];
+
+const child = spawn(command, args, {
+  stdio: 'inherit',
+});
+
+child.on('close', (code) => {
+  process.exit(code ?? 0);
+});
+
+child.on('error', (error) => {
+  console.error('Falha ao executar o Playwright Codegen:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- wrap `playwright codegen` in a Node script that loads `env/.env` with dotenv
- point the npm `codegen` script at the new wrapper so it works across POSIX shells and Windows cmd
- document the automatic environment loading behaviour in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cab170b00c83329de9314ad2d6bb78