### PR TITLE
Add full freight creation and negotiation e2e flow

### DIFF
--- a/src/pages/freight-negotiation.page.ts
+++ b/src/pages/freight-negotiation.page.ts
@@ -1,0 +1,105 @@
+import { expect, Page } from '@playwright/test';
+
+export type TravelStatus = 'in-transit' | 'delivered';
+
+export class FreightNegotiationPage {
+  constructor(private readonly page: Page) {}
+
+  async openConversationByReference(reference: string) {
+    await expect(this.page.getByTestId('negotiations-list')).toBeVisible();
+    await this.page
+      .getByTestId('freight-negotiation-card')
+      .filter({ hasText: new RegExp(reference, 'i') })
+      .first()
+      .click();
+    await expect(this.page.getByTestId('chat-message-input')).toBeVisible();
+  }
+
+  async postMessage(message: string) {
+    const input = this.page.getByTestId('chat-message-input');
+    await input.fill(message);
+    await input.press('Enter');
+    await expect(
+      this.page
+        .getByTestId('chat-message-bubble')
+        .filter({ hasText: new RegExp(message, 'i') })
+    ).toBeVisible();
+  }
+
+  async uploadAttachment(filePath: string) {
+    await this.page.getByTestId('chat-upload-trigger').click();
+    await this.page.getByTestId('chat-upload-input').setInputFiles(filePath);
+    await expect(this.page.getByTestId('chat-upload-success')).toBeVisible();
+  }
+
+  async moveToHomologation(message: string) {
+    await this.openActionsMenu();
+    await this.page.getByTestId('action-move-homologation').click();
+    await this.postMessage(message);
+    await this.assertStatusChip('Homologação');
+  }
+
+  async moveToApproved(message: string) {
+    await this.openActionsMenu();
+    await this.page.getByTestId('action-move-approved').click();
+    await this.postMessage(message);
+    await this.assertStatusChip('Aprovado');
+  }
+
+  async confirmApproval(message: string) {
+    await this.postMessage(message);
+    await expect(
+      this.page
+        .getByTestId('chat-message-bubble')
+        .filter({ hasText: new RegExp(message, 'i') })
+    ).toBeVisible();
+  }
+
+  async updateTravelStatus(status: TravelStatus) {
+    await this.page.getByTestId('select-travel-status').click();
+    const optionTestId =
+      status === 'in-transit' ? 'travel-status-in-transit' : 'travel-status-delivered';
+    await this.page.getByTestId(optionTestId).click();
+    await this.assertTripStatus(status === 'in-transit' ? 'Em trânsito' : 'Entregue');
+  }
+
+  async openFreightDataTab() {
+    await this.page.getByTestId('tab-freight-data').click();
+    await expect(this.page.getByTestId('freight-data-panel')).toBeVisible();
+  }
+
+  async openTripsTab() {
+    await this.page.getByTestId('tab-trips').click();
+    await expect(this.page.getByTestId('trips-panel')).toBeVisible();
+  }
+
+  async openNegotiationsTab() {
+    await this.page.getByTestId('tab-negotiations').click();
+    await expect(this.page.getByTestId('negotiations-list')).toBeVisible();
+  }
+
+  async openDriverDataTab() {
+    await this.page.getByTestId('tab-driver-data').click();
+    await expect(this.page.getByTestId('driver-data-panel')).toBeVisible();
+  }
+
+  private async openActionsMenu() {
+    await this.page.getByTestId('negotiation-actions-trigger').click();
+  }
+
+  private async assertStatusChip(expected: string) {
+    await expect(
+      this.page
+        .getByTestId('negotiation-status-chip')
+        .filter({ hasText: new RegExp(expected, 'i') })
+    ).toBeVisible();
+  }
+
+  private async assertTripStatus(expected: string) {
+    await expect(
+      this.page
+        .getByTestId('trip-status-chip')
+        .filter({ hasText: new RegExp(expected, 'i') })
+    ).toBeVisible();
+  }
+}

--- a/src/pages/freight-wizard.page.ts
+++ b/src/pages/freight-wizard.page.ts
@@ -1,0 +1,138 @@
+import { expect, Page } from '@playwright/test';
+
+type StopType = 'coleta' | 'descarga';
+
+export interface FreightStop {
+  type: StopType;
+  country: string;
+  address: string;
+  suggestion?: string;
+}
+
+export interface FreightCargo {
+  product: string;
+  weightInTon?: string;
+  hasTracker: boolean;
+  pickupDate: string;
+}
+
+export interface FreightVehicle {
+  bodyTypes: string[];
+  equipments?: string[];
+}
+
+export interface FreightPayment {
+  total: string;
+  method: string;
+  advancePercentage?: string;
+}
+
+export interface FreightFinishing {
+  assignDrivers: boolean;
+  notes?: string;
+}
+
+export class FreightWizardPage {
+  constructor(private readonly page: Page) {}
+
+  async fillStopsStep(stops: FreightStop[]) {
+    await expect(this.page.getByTestId('wizard-step-stops')).toBeVisible();
+
+    for (const [index, stop] of stops.entries()) {
+      if (index > 0) {
+        await this.page.getByTestId('btn-add-stop').click();
+      }
+
+      await this.selectStopType(index, stop.type);
+      await this.selectStopCountry(index, stop.country);
+      await this.fillStopAddress(index, stop.address, stop.suggestion);
+    }
+
+    await this.page.getByTestId('wizard-next').click();
+    await expect(this.page.getByTestId('wizard-step-cargo')).toBeVisible();
+  }
+
+  async fillCargoStep(cargo: FreightCargo) {
+    const trackerTestId = cargo.hasTracker ? 'radio-tracker-yes' : 'radio-tracker-no';
+    await this.page.getByTestId(trackerTestId).click();
+
+    await this.page.getByTestId('input-cargo-product').fill(cargo.product);
+
+    if (cargo.weightInTon) {
+      await this.page.getByTestId('input-cargo-weight').fill(cargo.weightInTon);
+    }
+
+    await this.page.getByTestId('input-cargo-pickup-date').fill(cargo.pickupDate);
+
+    await this.page.getByTestId('wizard-next').click();
+    await expect(this.page.getByTestId('wizard-step-vehicle')).toBeVisible();
+  }
+
+  async fillVehicleStep(vehicle: FreightVehicle) {
+    for (const bodyType of vehicle.bodyTypes) {
+      await this.page.getByTestId(`vehicle-type-${bodyType}`).check({ force: true });
+    }
+
+    for (const equipment of vehicle.equipments ?? []) {
+      await this.page.getByTestId(`vehicle-equipment-${equipment}`).check({ force: true });
+    }
+
+    await this.page.getByTestId('wizard-next').click();
+    await expect(this.page.getByTestId('wizard-step-payment')).toBeVisible();
+  }
+
+  async fillPaymentStep(payment: FreightPayment) {
+    await this.page.getByTestId('input-payment-total').fill(payment.total);
+    await this.page.getByTestId('select-payment-method').click();
+    await this.page
+      .getByTestId('option-payment-method')
+      .filter({ hasText: new RegExp(payment.method, 'i') })
+      .first()
+      .click();
+
+    if (payment.advancePercentage) {
+      await this.page.getByTestId('input-payment-advance').fill(payment.advancePercentage);
+    }
+
+    await this.page.getByTestId('wizard-next').click();
+    await expect(this.page.getByTestId('wizard-step-summary')).toBeVisible();
+  }
+
+  async finishFreightStep(finishing: FreightFinishing) {
+    const assignTestId = finishing.assignDrivers
+      ? 'radio-assign-drivers-yes'
+      : 'radio-assign-drivers-no';
+    await this.page.getByTestId(assignTestId).click();
+
+    if (finishing.notes) {
+      await this.page.getByTestId('input-freight-notes').fill(finishing.notes);
+    }
+
+    await this.page.getByTestId('btn-create-freight').click();
+    await expect(this.page.getByTestId('toast-freight-created')).toBeVisible();
+  }
+
+  private async selectStopType(index: number, type: StopType) {
+    const testId = type === 'coleta' ? 'radio-stop-pickup' : 'radio-stop-dropoff';
+    await this.page.getByTestId(testId).nth(index).check();
+  }
+
+  private async selectStopCountry(index: number, country: string) {
+    await this.page.getByTestId('stop-country-select').nth(index).click();
+    await this.page
+      .getByTestId('stop-country-option')
+      .filter({ hasText: new RegExp(country, 'i') })
+      .first()
+      .click();
+  }
+
+  private async fillStopAddress(index: number, address: string, suggestion?: string) {
+    await this.page.getByTestId('stop-address-input').nth(index).fill(address);
+    const suggestionText = suggestion ?? address;
+    await this.page
+      .getByTestId('stop-address-suggestion')
+      .filter({ hasText: new RegExp(suggestionText, 'i') })
+      .first()
+      .click();
+  }
+}

--- a/src/pages/fretes.page.ts
+++ b/src/pages/fretes.page.ts
@@ -8,8 +8,17 @@ export class FretesPage {
     await this.page.getByTestId('menu-fretes').click();
   }
 
-  async createFrete(origem: string, destino: string) {
+  async openNegotiationPanel() {
+    await this.page.getByTestId('menu-fretes-negociacoes').click();
+  }
+
+  async startNewFreight() {
     await this.page.getByTestId('btn-novo-frete').click();
+    await expect(this.page.getByTestId('wizard-step-stops')).toBeVisible();
+  }
+
+  async createFrete(origem: string, destino: string) {
+    await this.startNewFreight();
     await this.page.getByTestId('input-origem').fill(origem);
     await this.page.getByTestId('input-destino').fill(destino);
     await this.page.getByTestId('btn-salvar-frete').click();
@@ -28,5 +37,19 @@ export class FretesPage {
 
   async assertStatusCancelado() {
     await expect(this.page.getByTestId('frete-status')).toHaveText(/cancelado/i);
+  }
+
+  async openFreightOptions(reference: string) {
+    await this.page
+      .getByTestId('freight-card')
+      .filter({ hasText: new RegExp(reference, 'i') })
+      .first()
+      .getByTestId('freight-card-actions')
+      .click();
+  }
+
+  async concludeFreightFromMenu() {
+    await this.page.getByTestId('action-conclude-freight').click();
+    await expect(this.page.getByTestId('toast-freight-concluded')).toBeVisible();
   }
 }

--- a/src/tests/freight-complete-flow.spec.ts
+++ b/src/tests/freight-complete-flow.spec.ts
@@ -1,0 +1,81 @@
+import path from 'path';
+
+import { test } from '@fixtures/auth';
+import { FreightNegotiationPage } from '@pages/freight-negotiation.page';
+import { FreightWizardPage } from '@pages/freight-wizard.page';
+import { FretesPage } from '@pages/fretes.page';
+
+const attachmentPath = path.resolve('src/assets/logo-valida.png');
+
+test.describe('Frete - Fluxo completo (Admin)', () => {
+  test('Admin cria frete, negocia, homologa e conclui', async ({ page, loginAdmin }) => {
+    await loginAdmin();
+
+    const fretes = new FretesPage(page);
+    const wizard = new FreightWizardPage(page);
+    const negotiation = new FreightNegotiationPage(page);
+
+    const freightReference = `Auto Frete ${Date.now()}`;
+
+    await fretes.openList();
+    await fretes.startNewFreight();
+
+    await wizard.fillStopsStep([
+      {
+        type: 'coleta',
+        country: 'Brasil',
+        address: 'Porto Alegre, RS, Brasil',
+      },
+      {
+        type: 'descarga',
+        country: 'Brasil',
+        address: 'Viamão, RS, Brasil',
+      },
+    ]);
+
+    await wizard.fillCargoStep({
+      product: freightReference,
+      weightInTon: '4',
+      hasTracker: false,
+      pickupDate: '2025-09-20',
+    });
+
+    await wizard.fillVehicleStep({
+      bodyTypes: ['bitrem', 'bitruck', 'carreta', 'carreta-ls', 'truck'],
+      equipments: ['grade-baixa', 'graneleiro-grade-alta'],
+    });
+
+    await wizard.fillPaymentStep({
+      total: '4000',
+      method: 'Pix',
+      advancePercentage: '80',
+    });
+
+    await wizard.finishFreightStep({
+      assignDrivers: true,
+      notes: 'Envie os documentos',
+    });
+
+    await fretes.openNegotiationPanel();
+
+    await negotiation.openConversationByReference(freightReference);
+    await negotiation.postMessage('oi isso é um teste');
+    await negotiation.uploadAttachment(attachmentPath);
+
+    await negotiation.moveToHomologation('envie os documentos');
+    await negotiation.moveToApproved('tudo certo');
+    await negotiation.confirmApproval('foi aprovado');
+
+    await negotiation.updateTravelStatus('in-transit');
+    await negotiation.updateTravelStatus('delivered');
+
+    await negotiation.openFreightDataTab();
+    await negotiation.openTripsTab();
+    await negotiation.openNegotiationsTab();
+    await negotiation.openDriverDataTab();
+
+    await fretes.openList();
+    await fretes.openFreightOptions(freightReference);
+    await fretes.concludeFreightFromMenu();
+  });
+});


### PR DESCRIPTION
## Summary
- add a freight creation wizard page object that relies on data-testid selectors for each step
- add a negotiation page object to move the freight across negotiation and travel statuses
- extend the fretes helper and add an end-to-end spec that covers creation, negotiation and conclusion of a freight

## Testing
- npm test *(fails: Playwright browsers are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cabfda2cd08332afe2b0d6c4cf7dbe