### PR TITLE
refactor: support payload attachments in freight flow

### DIFF
--- a/src/pages/freight-negotiation.page.ts
+++ b/src/pages/freight-negotiation.page.ts
@@ -1,5 +1,7 @@
 import { expect, Page, type FilePayload } from '@playwright/test';
 
+type NegotiationAttachment = string | string[] | FilePayload | FilePayload[];
+
 export type TravelStatus = 'in-transit' | 'delivered';
 
 export class FreightNegotiationPage {
@@ -26,7 +28,7 @@ export class FreightNegotiationPage {
     ).toBeVisible();
   }
 
-  async uploadAttachment(file: string | FilePayload) {
+  async uploadAttachment(file: NegotiationAttachment) {
     await this.page.getByTestId('chat-upload-trigger').click();
     await this.page.getByTestId('chat-upload-input').setInputFiles(file);
     await expect(this.page.getByTestId('chat-upload-success')).toBeVisible();

--- a/src/tests/freight-complete-flow.spec.ts
+++ b/src/tests/freight-complete-flow.spec.ts
@@ -6,16 +6,17 @@ import { FreightNegotiationPage } from '@pages/freight-negotiation.page';
 import { FreightWizardPage } from '@pages/freight-wizard.page';
 import { FretesPage } from '@pages/fretes.page';
 
-const createAttachmentPayload = (): FilePayload => {
-  const base64Content =
-    'VGhpcyBpcyBhIHRlc3QgZG9jdW1lbnQgZm9yIGZyZWlnaHQgbmVnb3RpYXRpb24u';
+const NEGOTIATION_ATTACHMENT = {
+  name: 'negotiation-note.txt',
+  mimeType: 'text/plain',
+  base64Content: 'VGhpcyBpcyBhIHRlc3QgZG9jdW1lbnQgZm9yIGZyZWlnaHQgbmVnb3RpYXRpb24u',
+} as const;
 
-  return {
-    name: 'negotiation-note.txt',
-    mimeType: 'text/plain',
-    buffer: Buffer.from(base64Content, 'base64'),
-  };
-};
+const createAttachmentPayload = (): FilePayload => ({
+  name: NEGOTIATION_ATTACHMENT.name,
+  mimeType: NEGOTIATION_ATTACHMENT.mimeType,
+  buffer: Buffer.from(NEGOTIATION_ATTACHMENT.base64Content, 'base64'),
+});
 
 test.describe('Frete - Fluxo completo (Admin)', () => {
   test('Admin cria frete, negocia, homologa e conclui', async ({ page, loginAdmin }) => {


### PR DESCRIPTION
## Summary
- encapsulate the freight negotiation attachment data in a reusable payload helper built from a base64 string
- allow `FreightNegotiationPage.uploadAttachment` to forward both file paths and in-memory payloads to Playwright

## Testing
- npx playwright test src/tests/freight-complete-flow.spec.ts *(fails: Playwright browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cae1aae91083329160261fc5f98ab6