### PR TITLE
Support Auth0 login flow detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,12 @@ Antes de instalar, garanta que seu ambiente possui:
    BASE_URL="https://sua-aplicacao.com"
    ADMIN_EMAIL="admin@example.com"
    ADMIN_PASSWORD="senha-super-secreta"
+    AUTH_PROVIDER="internal"
    ```
    > Observação: informe apenas o domínio (sem caminhos ou parâmetros). Fluxos especiais, como redirecionamentos ou autenticações externas, exigem ajustes no código dos testes para que o fluxo seja reproduzido corretamente.
+   >
+   > - `AUTH_PROVIDER` é opcional. Quando ausente, a fixture tenta detectar automaticamente se a URL de login está hospedada no Auth0 (`auth0.com`) para usar os seletores apropriados.
+   > - Defina `AUTH_PROVIDER=auth0` para forçar o uso dos seletores do provedor mesmo em domínios personalizados, ou `AUTH_PROVIDER=internal` para manter o formulário nativo.
 3. Novas chaves podem ser adicionadas ao `.env` conforme necessidade. Tudo é carregado automaticamente antes de cada teste.
 
 ## Executar os testes

--- a/env/.env.example
+++ b/env/.env.example
@@ -5,3 +5,7 @@ BASE_URL=https://app.seudominio.com
 # Credenciais do Admin
 ADMIN_EMAIL=user@wnslog.com
 ADMIN_PASSWORD=Nexxo@12345
+
+# Força seletores de login específicos (opções: internal, auth0).
+# Deixe em branco para detecção automática baseada no domínio após o redirecionamento.
+AUTH_PROVIDER=internal

--- a/src/fixtures/auth.ts
+++ b/src/fixtures/auth.ts
@@ -1,5 +1,38 @@
 
-import { test as base, expect } from '@playwright/test';
+import { test as base, expect, Page } from '@playwright/test';
+
+const shouldUseAuth0Selectors = (url: string) => {
+  const provider = process.env.AUTH_PROVIDER?.toLowerCase();
+
+  if (provider === 'auth0') {
+    return true;
+  }
+
+  if (provider === 'internal') {
+    return false;
+  }
+
+  const normalizedUrl = url?.toLowerCase() ?? '';
+
+  return normalizedUrl.includes('auth0.com');
+};
+
+const fillInternalLoginForm = async (page: Page, email: string, password: string) => {
+  await page.getByTestId('input-email').fill(email);
+  await page.getByTestId('input-password').fill(password);
+  await page.getByTestId('btn-login').click();
+};
+
+const fillAuth0LoginForm = async (page: Page, email: string, password: string) => {
+  const usernameInput = page.locator('input[name="username"]');
+  await usernameInput.waitFor({ state: 'visible' });
+  await usernameInput.fill(email);
+
+  const passwordInput = page.locator('input[name="password"]');
+  await passwordInput.fill(password);
+
+  await page.getByRole('button', { name: /continuar|entrar/i }).click();
+};
 
 export const test = base.extend<{
   loginAdmin: () => Promise<void>;
@@ -7,9 +40,13 @@ export const test = base.extend<{
   loginAdmin: async ({ page }, use) => {
     const fn = async () => {
       await page.goto('/');
-      await page.getByTestId('input-email').fill(process.env.ADMIN_EMAIL!);
-      await page.getByTestId('input-password').fill(process.env.ADMIN_PASSWORD!);
-      await page.getByTestId('btn-login').click();
+
+      const useAuth0 = shouldUseAuth0Selectors(page.url());
+      if (useAuth0) {
+        await fillAuth0LoginForm(page, process.env.ADMIN_EMAIL!, process.env.ADMIN_PASSWORD!);
+      } else {
+        await fillInternalLoginForm(page, process.env.ADMIN_EMAIL!, process.env.ADMIN_PASSWORD!);
+      }
       await expect(page).toHaveURL(/dashboard|home|fretes/i);
     };
     await use(fn);

--- a/src/pages/login.page.ts
+++ b/src/pages/login.page.ts
@@ -1,6 +1,39 @@
 
 import { Page, expect } from '@playwright/test';
 
+const shouldUseAuth0Selectors = (url: string) => {
+  const provider = process.env.AUTH_PROVIDER?.toLowerCase();
+
+  if (provider === 'auth0') {
+    return true;
+  }
+
+  if (provider === 'internal') {
+    return false;
+  }
+
+  const normalizedUrl = url?.toLowerCase() ?? '';
+
+  return normalizedUrl.includes('auth0.com');
+};
+
+const fillInternalLoginForm = async (page: Page, email: string, password: string) => {
+  await page.getByTestId('input-email').fill(email);
+  await page.getByTestId('input-password').fill(password);
+  await page.getByTestId('btn-login').click();
+};
+
+const fillAuth0LoginForm = async (page: Page, email: string, password: string) => {
+  const usernameInput = page.locator('input[name="username"]');
+  await usernameInput.waitFor({ state: 'visible' });
+  await usernameInput.fill(email);
+
+  const passwordInput = page.locator('input[name="password"]');
+  await passwordInput.fill(password);
+
+  await page.getByRole('button', { name: /continuar|entrar/i }).click();
+};
+
 export class LoginPage {
   constructor(private page: Page) {}
 
@@ -9,9 +42,13 @@ export class LoginPage {
   }
 
   async login(email: string, password: string) {
-    await this.page.getByTestId('input-email').fill(email);
-    await this.page.getByTestId('input-password').fill(password);
-    await this.page.getByTestId('btn-login').click();
+    const useAuth0 = shouldUseAuth0Selectors(this.page.url());
+
+    if (useAuth0) {
+      await fillAuth0LoginForm(this.page, email, password);
+    } else {
+      await fillInternalLoginForm(this.page, email, password);
+    }
   }
 
   async assertLoggedIn() {


### PR DESCRIPTION
## Summary
- detect Auth0-hosted login pages in the shared auth fixture and fall back to the internal form selectors when needed
- apply the same logic to the login page object so tests can interact with either provider
- document the optional AUTH_PROVIDER environment toggle in the README and sample .env file

## Testing
- npx tsc --noEmit *(fails: existing FilePayload import error in other pages/tests)*

------
https://chatgpt.com/codex/tasks/task_e_68caec72d7a0833286da0b64264f744e