### PR TITLE
Ajusta filtro de detalhe de frete e cobre múltiplos fretes

### DIFF
--- a/src/pages/fretes.page.ts
+++ b/src/pages/fretes.page.ts
@@ -26,7 +26,11 @@ export class FretesPage {
 
   async openDetalheDoFretePorTexto(texto: string) {
     // Requer que a sua tabela/linha tenha data-testid de detalhe ou link
-    await this.page.getByTestId('link-detalhe-frete', { hasText: texto }).first().click();
+    await this.page
+      .getByTestId('link-detalhe-frete')
+      .filter({ hasText: texto })
+      .first()
+      .click();
   }
 
   async cancelarFrete(motivo: string) {

--- a/src/tests/freight-cancel.spec.ts
+++ b/src/tests/freight-cancel.spec.ts
@@ -1,5 +1,5 @@
 
-import { test } from '@fixtures/auth';
+import { expect, test } from '@fixtures/auth';
 import { FretesPage } from '@pages/fretes.page';
 
 test.describe('Frete - Cancelar (Admin)', () => {
@@ -9,7 +9,16 @@ test.describe('Frete - Cancelar (Admin)', () => {
 
     await fretes.openList();
     await fretes.createFrete('Porto Alegre - RS', 'São Paulo - SP');
-    await fretes.openDetalheDoFretePorTexto('Porto Alegre');
+
+    await fretes.openList();
+    const origemSegundoFrete = 'Curitiba - PR';
+    const destinoSegundoFrete = 'Rio de Janeiro - RJ';
+    await fretes.createFrete(origemSegundoFrete, destinoSegundoFrete);
+
+    await fretes.openDetalheDoFretePorTexto('Curitiba');
+    await expect(page.getByText(origemSegundoFrete, { exact: false })).toBeVisible();
+    await expect(page.getByText(destinoSegundoFrete, { exact: false })).toBeVisible();
+
     await fretes.cancelarFrete('Cliente desistiu');
     await fretes.assertStatusCancelado();
   });


### PR DESCRIPTION
## Summary
- encadeia o filtro `hasText` após recuperar o test id do link de detalhe de frete
- expande o teste de cancelamento para criar dois fretes e garantir que o detalhe correto é aberto

## Testing
- npm test *(falha: navegadores do Playwright não instalados no ambiente)*

------
https://chatgpt.com/codex/tasks/task_e_68caef711a34833291f9b4faaaa5e7c8