### PR TITLE
Update upload logo test to use import.meta.url

### DIFF
--- a/src/tests/upload-logo.spec.ts
+++ b/src/tests/upload-logo.spec.ts
@@ -1,7 +1,10 @@
 
 import { test } from '@fixtures/auth';
 import { SettingsPage } from '@pages/settings.page';
-import path from 'path';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
 
 test.describe('Upload de Logo (Admin)', () => {
   test('upload válido e preview', async ({ page, loginAdmin }) => {
@@ -9,7 +12,7 @@ test.describe('Upload de Logo (Admin)', () => {
     const settings = new SettingsPage(page);
     await settings.open();
 
-    const filePath = path.resolve(__dirname, '../assets/logo-valida.png');
+    const filePath = path.resolve(testDir, '../assets/logo-valida.png');
     await settings.uploadLogoOk(filePath);
     await settings.assertToastSuccess();
   });
@@ -19,7 +22,7 @@ test.describe('Upload de Logo (Admin)', () => {
     const settings = new SettingsPage(page);
     await settings.open();
 
-    const filePath = path.resolve(__dirname, '../assets/invalido.pdf');
+    const filePath = path.resolve(testDir, '../assets/invalido.pdf');
     await page.getByTestId('input-logo').setInputFiles(filePath);
     await settings.assertToastUploadError();
   });


### PR DESCRIPTION
## Summary
- replace the path import to use node namespace and add fileURLToPath
- resolve the test directory from import.meta.url and use it for asset paths

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cafe07ab248332ba2cf2b126b157ba